### PR TITLE
Refactor pass_command to use lazy loading

### DIFF
--- a/bwtv.py
+++ b/bwtv.py
@@ -107,7 +107,7 @@ def _fetch_secret(site, secret_id):
     secret = response.json()
 
     try:
-        response = session.get(secret['current_revision'] + "data", auth=credentials)
+        response = session.get(secret['current_revision'] + "data", auth=cached_credentials[site])
     except RequestException as e:
         raise FaultUnavailable(
             "Exception while getting secret {secret} from TeamVault: {exc}".format(


### PR DESCRIPTION
The new mechanism will only run pass_command when getting a password
from teamvault for the first time instead of on every read of the
configuration file.